### PR TITLE
fixed fetching azure ip ranges

### DIFF
--- a/email_spoof_check.py
+++ b/email_spoof_check.py
@@ -69,7 +69,7 @@ if not isfile("IPs.txt") or args.refresh_ips:
 	azureIndirect = get("https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519", headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:102.0) Gecko/20100101 Firefox/102.0"}).text.split("\n")
 	for i, line in enumerate(azureIndirect):
 		if "30 seconds" in line:
-			azureDirect = azureIndirect[i+1].split(".json\"")[0].split('"')[-1] + ".json"
+			azureDirect = line.split("\"url\":")[1].split("\"")[1]	
 	json = get(azureDirect).json()
 	for value in json["values"]:
 		if "AzureCloud" in value["name"]:


### PR DESCRIPTION
seems like the page at https://www.microsoft.com/en-us/download/details.aspx?id=56519 that the tool scrapes to get the azure data link has been changed, causing tool to break. updated line 73 to properly extract the link again.